### PR TITLE
support more flexible date filtering

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,11 @@
       "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
       "@typescript-eslint/ban-ts-comment": "off",
       "no-prototype-builtins": "off",
-      "@typescript-eslint/no-empty-function": "off"
+      "@typescript-eslint/no-empty-function": "off",
+      // Use single quotes
+      "quotes": ["error", "single"],
+      // Don't require semi colons
+      "semi": ["error", "never"],
+      "arrow-parens": ["error", "as-needed"], 
     } 
   }

--- a/package.json
+++ b/package.json
@@ -6,22 +6,25 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"version": "node version-bump.mjs && git add manifest.json versions.json"
+		"version": "node version-bump.mjs && git add manifest.json versions.json",
+		"lint": "eslint . --ext .ts",
+		"lint:fix": "eslint . --ext .ts --fix"
 	},
 	"keywords": [],
 	"author": "Alan Grainger",
 	"license": "GPL-3.0-or-later",
 	"devDependencies": {
 		"@electron/remote": "^2.0.8",
+		"@popperjs/core": "^2.11.6",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.14.47",
+		"eslint": "^8.47.0",
+		"litepicker": "^2.0.12",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4",
-		"@popperjs/core": "^2.11.6",
-		"litepicker": "^2.0.12"
+		"typescript": "4.7.4"
 	}
 }

--- a/src/photoModal.ts
+++ b/src/photoModal.ts
@@ -206,7 +206,8 @@ export class DailyPhotosModal extends PhotosModal {
       const frontMatter = file?.frontmatter
       if (frontMatter && frontMatter[this.plugin.settings.getDateFromFrontMatterKey]) {
         return moment(frontMatter[this.plugin.settings.getDateFromFrontMatterKey], this.plugin.settings.getDateFromFormat, true)
-      }
+      } 
+      return moment('invalid date')
     }
     // GetDateFromOptions.TODAY option, use today's date
     return moment()

--- a/src/photoModal.ts
+++ b/src/photoModal.ts
@@ -1,4 +1,4 @@
-import { App, Editor, MarkdownView, Modal, moment, Platform, requestUrl, Setting, ToggleComponent } from 'obsidian'
+import { App, Editor, MarkdownView, Modal, moment, Notice, Platform, requestUrl, Setting, ToggleComponent } from 'obsidian'
 import { GridView, ThumbnailImage } from './renderer'
 import GooglePhotos from './main'
 import { handlebarParse } from './handlebars'
@@ -145,19 +145,21 @@ export class DailyPhotosModal extends PhotosModal {
     // Check for a valid date from the note title
     this.noteDate = await this.getDateUsingSetting()
     if (this.noteDate.isValid()) {
-      // Determine the date range to show photos in
-      if (this.plugin.settings.showPhotosInDateRange) {
-        this.xDaysBeforeDate = moment(this.noteDate).subtract(this.plugin.settings.showPhotosXDaysPast, 'days')
-        this.xDaysAfterDate = moment(this.noteDate).add(this.plugin.settings.showPhotosXDaysFuture, 'days')
-      }
       // The currently open note has a parsable date
       if (this.plugin.settings.defaultToDailyPhotos) {
         // Set the default view to show photos from today
         this.limitPhotosToNoteDate = true
       }
     } else {
+      new Notice(`Unable to parse date from ${lowerCaseFirstLetter(this.plugin.settings.getDateFrom)} with format ${this.plugin.settings.getDateFromFormat}. Using today's date instead.`)
       // Set to today's date if there is not note date
       this.noteDate = moment()
+    }
+
+    // Determine the date range to show photos in
+    if (this.plugin.settings.showPhotosInDateRange) {
+      this.xDaysBeforeDate = moment(this.noteDate).subtract(this.plugin.settings.showPhotosXDaysPast, 'days')
+      this.xDaysAfterDate = moment(this.noteDate).add(this.plugin.settings.showPhotosXDaysFuture, 'days')
     }
 
     // Create the date picker
@@ -234,4 +236,8 @@ function dateToGoogleDateFilter(date: moment.Moment) {
     month: +date.format('M'),
     day: +date.format('D')
   }
+}
+
+function lowerCaseFirstLetter(string: string) {
+  return string.charAt(0).toLowerCase() + string.slice(1)
 }

--- a/src/photosApi.ts
+++ b/src/photosApi.ts
@@ -1,6 +1,27 @@
 import { moment } from 'obsidian'
 import GooglePhotos from './main'
 
+export type GooglePhotosDate = {
+  year: number;
+  month: number;
+  day: number;
+}
+
+// https://developers.google.com/photos/library/reference/rest/v1/mediaItems/search#DateFilter
+export type GooglePhotosDateFilter = {
+  dates?: Array<GooglePhotosDate>;
+  ranges?: {
+    startDate: GooglePhotosDate;
+    endDate: GooglePhotosDate;
+  }
+}
+
+export type GooglePhotosSearchParams = {
+  filters?: {
+    dateFilter?: GooglePhotosDateFilter 
+  }
+}
+
 export default class PhotosApi {
   plugin: GooglePhotos
 
@@ -17,7 +38,7 @@ export default class PhotosApi {
    *
    * @throws Will throw an error if the input is malformed, or if the user is not authenticated
    */
-  async request (endpoint: string, params = {}) {
+  async request (endpoint: string, params: GooglePhotosSearchParams = {}) {
     // Check to make sure we have a valid access token
     const s = this.plugin.settings
     if (!s.accessToken || moment() > moment(s.expires)) {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,6 +1,7 @@
 import { moment, Notice } from 'obsidian'
 import GooglePhotos from './main'
 import { Moment } from 'moment'
+import { GooglePhotosSearchParams } from 'photosApi'
 
 export class ThumbnailImage extends Image {
   photoId: string
@@ -73,7 +74,7 @@ export class GridView extends Renderer {
   scrollEl: HTMLElement
   containerEl: HTMLElement
   gridEl: HTMLElement
-  searchParams: object = {}
+  searchParams: GooglePhotosSearchParams = {}
   plugin: GooglePhotos
   onThumbnailClick: Function = () => {}
   nextPageToken: string
@@ -119,7 +120,7 @@ export class GridView extends Renderer {
     this.moreResults = true
   }
 
-  setSearchParams (searchParams: object) {
+  setSearchParams (searchParams: GooglePhotosSearchParams) {
     this.searchParams = searchParams
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,12 @@ import { App, moment, PluginSettingTab, Setting } from 'obsidian'
 import { FolderSuggest } from './suggesters/FolderSuggester'
 import GooglePhotos from './main'
 
+export enum GetDateFromOptions {
+  NOTE_TITLE = 'Note\'s title',
+  FRONT_MATTER = 'Note\'s front matter',
+  USE_TODAY = 'Use today\'s date',
+}
+
 export interface GooglePhotosSettings {
   clientId: string;
   clientSecret: string;
@@ -12,11 +18,18 @@ export interface GooglePhotosSettings {
   thumbnailHeight: number;
   filename: string;
   thumbnailMarkdown: string;
-  parseNoteTitle: string;
   defaultToDailyPhotos: boolean;
   locationOption: string;
   locationFolder: string;
   locationSubfolder: string;
+
+  getDateFrom: GetDateFromOptions;
+  getDateFromFrontMatterKey: string;
+  getDateFromFormat: string;
+
+  showPhotosInDateRange: boolean;
+  showPhotosXDaysPast: number;
+  showPhotosXDaysFuture: number;
 }
 
 export const DEFAULT_SETTINGS: GooglePhotosSettings = {
@@ -29,11 +42,18 @@ export const DEFAULT_SETTINGS: GooglePhotosSettings = {
   thumbnailHeight: 280,
   filename: 'YYYY-MM-DD[_google-photo_]HHmmss[.jpg]',
   thumbnailMarkdown: '[![]({{local_thumbnail_link}})]({{google_photo_url}}) ',
-  parseNoteTitle: 'YYYY-MM-DD',
   defaultToDailyPhotos: true,
   locationOption: 'note',
   locationFolder: '',
-  locationSubfolder: 'photos'
+  locationSubfolder: 'photos',
+
+  getDateFrom: GetDateFromOptions.NOTE_TITLE,
+  getDateFromFrontMatterKey: 'date',
+  getDateFromFormat: 'YYYY-MM-DD',
+
+  showPhotosInDateRange: false,
+  showPhotosXDaysPast: 7,
+  showPhotosXDaysFuture: 1,
 }
 
 export class GooglePhotosSettingTab extends PluginSettingTab {
@@ -243,11 +263,11 @@ export class GooglePhotosSettingTab extends PluginSettingTab {
      */
 
     new Setting(containerEl)
-      .setName('Other  settings')
+      .setName('Date settings')
       .setHeading()
     new Setting(containerEl)
-      .setName('Default to showing photos from note date')
-      .setDesc('If the plugin detects you are on a daily note, it can default to show you photos from that date.')
+      .setName('Default to limiting shown photos to date(s)')
+      .setDesc('Choose to limit the photos shown in popup modal to a specific date(s) determined by the option below.')
       .addToggle(toggle => {
         toggle
           .setValue(this.plugin.settings.defaultToDailyPhotos)
@@ -256,22 +276,159 @@ export class GooglePhotosSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings()
           })
       })
+
+    // Provide three options in a dropdown for how to parse the date to use for the photo search
     new Setting(containerEl)
-      .setName('Daily note date format')
-      .addText(text => text
-        .setPlaceholder(DEFAULT_SETTINGS.parseNoteTitle)
-        .setValue(this.plugin.settings.parseNoteTitle)
-        .onChange(async (value) => {
-          this.plugin.settings.parseNoteTitle = value.trim()
-          await this.plugin.saveSettings()
-        }))
+      .setName('Determine date from')
+      .addDropdown(dropdown =>
+        dropdown
+          .addOption(
+            GetDateFromOptions.NOTE_TITLE,
+            GetDateFromOptions.NOTE_TITLE
+          )
+          .addOption(
+            GetDateFromOptions.FRONT_MATTER,
+            GetDateFromOptions.FRONT_MATTER
+          )
+          .addOption(GetDateFromOptions.USE_TODAY, GetDateFromOptions.USE_TODAY)
+          .setValue(this.plugin.settings.getDateFrom)
+          .onChange(async (value: GetDateFromOptions) => {
+            this.plugin.settings.getDateFrom = value
+            await this.plugin.saveSettings()
+            this.display()
+          })
+      )
       .then(setting => {
-        setting.descEl.appendText('This is the ')
-        setting.descEl.createEl('a', {
-          text: 'MomentJS date format',
-          href: 'https://momentjs.com/docs/#/displaying/format/',
-        })
-        setting.descEl.appendText(' used in the title of your daily notes, so we can parse them back to a date.')
+        setting.descEl.appendText(
+          'The source of determining the date used to search for photos.'
+        )
+        setting.descEl.createEl('br')
+        const ul = setting.descEl.createEl('ul')
+        ul.createEl('li').setText(
+          `${GetDateFromOptions.NOTE_TITLE} - The date will be parsed from the note's title, using the format below.`
+        )
+        ul.createEl('li').setText(
+          `${GetDateFromOptions.FRONT_MATTER} - The date will be parsed from the note's front matter, using the property and format below.`
+        )
+        ul.createEl('li').setText(
+          `${GetDateFromOptions.USE_TODAY} - Today's date will be used.`
+        )
       })
-  }
+
+    if (this.plugin.settings.getDateFrom === GetDateFromOptions.NOTE_TITLE) {
+      new Setting(containerEl)
+        .setName('Title date format')
+        .addText(text =>
+          text
+            .setPlaceholder(DEFAULT_SETTINGS.getDateFromFormat)
+            .setValue(this.plugin.settings.getDateFromFormat)
+            .onChange(async value => {
+              this.plugin.settings.getDateFromFormat = value.trim()
+              await this.plugin.saveSettings()
+            })
+        )
+        .then(setting => {
+          setting.descEl.appendText('This is the ')
+          setting.descEl.createEl('a', {
+            text: 'MomentJS date format',
+            href: 'https://momentjs.com/docs/#/displaying/format/',
+          })
+          setting.descEl.appendText(
+            ' used in the title of your daily notes, so we can parse them back to a date.'
+          )
+        })
+    } else if (
+      this.plugin.settings.getDateFrom === GetDateFromOptions.FRONT_MATTER
+    ) {
+      new Setting(containerEl)
+        .setName('Front matter key')
+        .addText(text =>
+          text
+            .setPlaceholder(DEFAULT_SETTINGS.getDateFromFrontMatterKey)
+            .setValue(this.plugin.settings.getDateFromFrontMatterKey)
+            .onChange(async value => {
+              this.plugin.settings.getDateFromFrontMatterKey = value.trim()
+              await this.plugin.saveSettings()
+            })
+        )
+        .then(setting => {
+          setting.descEl.appendText(
+            'This is the name of the front matter property that contains the date.'
+          )
+        })
+      new Setting(containerEl)
+        .setName('Front matter date format')
+        .addText(text =>
+          text
+            .setPlaceholder(DEFAULT_SETTINGS.getDateFromFormat)
+            .setValue(this.plugin.settings.getDateFromFormat)
+            .onChange(async value => {
+              this.plugin.settings.getDateFromFormat = value.trim()
+              await this.plugin.saveSettings()
+            })
+        )
+        .then(setting => {
+          setting.descEl.appendText('This is the ')
+          setting.descEl.createEl('a', {
+            text: 'MomentJS date format',
+            href: 'https://momentjs.com/docs/#/displaying/format/',
+          })
+          setting.descEl.appendText(
+            ' used in the front matter property, so we can parse it back to a date.'
+          )
+        })
+    }  
+
+    new Setting(containerEl)
+      .setName('Show photos in range of days?')
+      .setDesc(`Enable to show photos between today and ${this.plugin.settings.showPhotosXDaysPast} days ago and ${this.plugin.settings.showPhotosXDaysFuture} days in the future.`)
+      .addToggle(toggle => {
+        toggle
+          .setValue(this.plugin.settings.showPhotosInDateRange)
+          .onChange(async (value) => {
+            this.plugin.settings.showPhotosInDateRange = value
+            await this.plugin.saveSettings()
+          })
+      })
+
+    new Setting(containerEl)
+      .setName('Number of days in the past')
+      .setDesc('Number of days in the past to show photos from.')
+      .addText(text => {
+        text
+        .setPlaceholder(DEFAULT_SETTINGS.showPhotosXDaysPast.toString())
+        .setValue(this.plugin.settings.showPhotosXDaysPast.toString())
+        .onChange(async (value) => {
+          if (isNaN(+value)) {
+            return
+          }
+          this.plugin.settings.showPhotosXDaysPast = +value
+          await this.plugin.saveSettings()
+        })
+        // Update display for above setting to update its description or to update validated value
+        text.inputEl.onblur = () => {
+          this.display()
+        }
+    })
+    
+    new Setting(containerEl)
+      .setName('Number of days in the future')
+      .setDesc('Number of days in the future to show photos from.')
+      .addText(text => { 
+        text
+        .setPlaceholder(DEFAULT_SETTINGS.showPhotosXDaysFuture.toString())
+        .setValue(this.plugin.settings.showPhotosXDaysFuture.toString())
+        .onChange(async (value) => {
+          if (isNaN(+value)) {
+            return
+          }
+          this.plugin.settings.showPhotosXDaysFuture = +value
+          await this.plugin.saveSettings()
+        })
+        // Update display for above setting to update its description or to update validated value
+        text.inputEl.onblur = () => {
+          this.display()
+        }
+      })
+   }
 }


### PR DESCRIPTION
Gotta start by saying I love this plugin and use it daily for journaling and mentioned it in [my journaling plugin](https://github.com/Ebonsignori/obsidian-auto-journal) (pending review to community plugins)

## Changes

This PR renamed "Other settings" to Date settings and added some features for more flexible date filtering

![image](https://github.com/alangrainger/obsidian-google-photos/assets/17055832/4806cc2f-3f7e-4567-933a-10a0ed95d741)

I really only wanted to load the day's dates from frontmatter since [Auto Journal](https://github.com/Ebonsignori/obsidian-auto-journal) supports replacing a token, I set the `date` frontmatter key in my frontmatter for each journal entry and since I'm often backfilling a journal entry from the day before I wanted the Google Photos filter to open for that day.

Ended up adding other logical choices for parsing the date and figured I'd tackle https://github.com/alangrainger/obsidian-google-photos/issues/14 while I was on a roll 😁 

Closes https://github.com/alangrainger/obsidian-google-photos/issues/14

## Linting ?

Just a suggestion you can push to this PR to remove, but I think you should add/enforce some sort of linting for this project. [My projects](https://github.com/Ebonsignori/obsidian-at-symbol-linking/blob/main/.eslintrc.js#L9) and editor is setup to use [prettier](https://github.com/prettier/eslint-config-prettier) by default. It looks like your style might be closer to [standard](https://github.com/standard/eslint-config-standard) since you don't use semicolons.

I tried to add some custom eslint rules to `.eslintrc` to reflect your style. You can run `npm run lint:fix` to automatically apply them if you like them or extend the config as you see fit. Either way, it's nice as a contributor to be able to run `npm run lint:fix` because I automatically had prettier fix a few files I was touching and had to manually go through and undo some of the formatting 🙃 

@alangrainger feel free to push to / change / merge this at will. It's your repo, I won't be offended 